### PR TITLE
 記事一つにつきタグは一つまでにした

### DIFF
--- a/src/lib/features/article/components/ArticleCard/ArticleCard.stories.ts
+++ b/src/lib/features/article/components/ArticleCard/ArticleCard.stories.ts
@@ -15,20 +15,12 @@ export const Default: Story = {
 			title: 'サンプル記事',
 			imageUrl: 'https://www.pokemon.co.jp/PostImages/d86fdbe4e3d1e9d680b5217f7d947425caae82aa.jpg',
 			body: 'これはサンプルの記事です。dfadfasdfasdfadf',
-			tags: [
-				{
-					id: '1',
-					name: 'サンプル',
-					iconUrl: 'https://icon-pit.com/wp-content/uploads/2018/10/note-pc_icon_79.png',
-					color: '#ff0000'
-				},
-				{
-					id: '2',
-					name: 'プログラミング',
-					iconUrl: 'https://icon-pit.com/wp-content/uploads/2018/10/note-pc_icon_79.png',
-					color: '#ff0000'
-				}
-			],
+			tag: {
+				id: '1',
+				name: 'サンプルタグ',
+				iconUrl: 'https://icon-pit.com/wp-content/uploads/2018/10/note-pc_icon_79.png',
+				color: '#ff0000'
+			},
 			createdAt: '2024-05-22T23:20:33.446Z',
 			updatedAt: '2024-05-22T23:20:33.446Z'
 		}

--- a/src/lib/features/article/components/ArticleCard/ArticleCard.svelte
+++ b/src/lib/features/article/components/ArticleCard/ArticleCard.svelte
@@ -10,11 +10,9 @@
 </script>
 
 <Card href="/" img={article.imageUrl} class="cursor-pointer" size="sm">
-	<ul class="w-full h-fit flex gap-x-2 mb-4">
-		{#each article.tags as tag}
-			<li><TagChip {tag} /></li>
-		{/each}
-	</ul>
+	<div class="mb-4">
+		<TagChip tag={article.tag} />
+	</div>
 	<h5 id="title" class="mb-10 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
 		{article.title}
 	</h5>

--- a/src/lib/features/article/components/ArticleCard/ArticleCard.test.ts
+++ b/src/lib/features/article/components/ArticleCard/ArticleCard.test.ts
@@ -14,7 +14,12 @@ describe('記事のカードコンポーネントのテスト', () => {
 			slug: '/',
 			createdAt: new Date(),
 			updatedAt: new Date(),
-			tags: []
+			tag: {
+				id: '1',
+				name: 'サンプルタグ',
+				iconUrl: 'https://icon-pit.com/wp-content/uploads/2018/10/note-pc_icon_79.png',
+				color: '#ff0000',
+			}
 		};
 		render(ArticleCard, { article: SAMPLE_ARTICLE });
 		const title = screen.queryByText(SAMPLE_ARTICLE.title);
@@ -29,8 +34,13 @@ describe('記事のカードコンポーネントのテスト', () => {
 			content: 'これはテストの記事です。',
 			slug: '/',
 			createdAt: dayjs().subtract(1, 'day').toDate(),
-			updatedAt: dayjs().subtract(1, 'day').toDate(),
-			tags: []
+			updatedAt: dayjs().subtract(1, 'day').toDate(), 
+			tag: {
+				id: '1',
+				name: 'サンプルタグ',
+				iconUrl: 'https://icon-pit.com/wp-content/uploads/2018/10/note-pc_icon_79.png',
+				color: '#ff0000',
+			}
 		};
 
 		render(ArticleCard, { article: SAMPLE_ARTICLE });
@@ -47,7 +57,12 @@ describe('記事のカードコンポーネントのテスト', () => {
 			slug: '/',
 			createdAt: dayjs().subtract(2, 'day').toDate(),
 			updatedAt: dayjs().subtract(1, 'day').toDate(),
-			tags: []
+			tag: {
+				id: '1',
+				name: 'サンプルタグ',
+				iconUrl: 'https://icon-pit.com/wp-content/uploads/2018/10/note-pc_icon_79.png',
+				color: '#ff0000',
+			},
 		};
 		render(ArticleCard, { article: SAMPLE_ARTICLE });
 		const date = screen.getByTestId('article-card-time');

--- a/src/lib/features/article/components/ArticleCard/ArticleCard.test.ts
+++ b/src/lib/features/article/components/ArticleCard/ArticleCard.test.ts
@@ -18,7 +18,7 @@ describe('記事のカードコンポーネントのテスト', () => {
 				id: '1',
 				name: 'サンプルタグ',
 				iconUrl: 'https://icon-pit.com/wp-content/uploads/2018/10/note-pc_icon_79.png',
-				color: '#ff0000',
+				color: '#ff0000'
 			}
 		};
 		render(ArticleCard, { article: SAMPLE_ARTICLE });
@@ -34,12 +34,12 @@ describe('記事のカードコンポーネントのテスト', () => {
 			content: 'これはテストの記事です。',
 			slug: '/',
 			createdAt: dayjs().subtract(1, 'day').toDate(),
-			updatedAt: dayjs().subtract(1, 'day').toDate(), 
+			updatedAt: dayjs().subtract(1, 'day').toDate(),
 			tag: {
 				id: '1',
 				name: 'サンプルタグ',
 				iconUrl: 'https://icon-pit.com/wp-content/uploads/2018/10/note-pc_icon_79.png',
-				color: '#ff0000',
+				color: '#ff0000'
 			}
 		};
 
@@ -61,8 +61,8 @@ describe('記事のカードコンポーネントのテスト', () => {
 				id: '1',
 				name: 'サンプルタグ',
 				iconUrl: 'https://icon-pit.com/wp-content/uploads/2018/10/note-pc_icon_79.png',
-				color: '#ff0000',
-			},
+				color: '#ff0000'
+			}
 		};
 		render(ArticleCard, { article: SAMPLE_ARTICLE });
 		const date = screen.getByTestId('article-card-time');

--- a/src/lib/features/article/types/type.ts
+++ b/src/lib/features/article/types/type.ts
@@ -8,5 +8,5 @@ export type Article = {
 	imageUrl: string;
 	createdAt: Date;
 	updatedAt: Date;
-	tags: Tag[];
+	tag: Tag; // 一つの記事に付けられるタグは一つまでにした（ややこしくなるのを防ぐため）
 };


### PR DESCRIPTION
### 変更理由
- タグが複数だと`ArticleCard`のスペース的に厳しい
- パンくずリストが作りにくい