### PR TITLE
Change : 検索ページのタグ表示をTagCardコンポーネントに変更

### DIFF
--- a/src/lib/features/tag/repositories/api/fetch.ts
+++ b/src/lib/features/tag/repositories/api/fetch.ts
@@ -14,7 +14,6 @@ const SAMPLE_TAG: Tag = {
 };
 
 const fetchTag: TagAPIsType['fetchTag'] = async (slug: string) => {
-	console.debug('fetchTag', slug);
 	return SAMPLE_TAG;
 };
 

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -4,10 +4,12 @@
 	import type { PageData } from './$types';
 	import ArticleVerticalCard from '$lib/features/article/components/ArticleVerticalCard/ArticleVerticalCard.svelte';
 	import ArticleVerticalCardSkeleton from '$lib/features/article/components/ArticleVerticalCard/Skeleton/ArticleVerticalCardSkeleton.svelte';
+	import TagCard from '$lib/features/tag/components/TagCard/TagCard.svelte';
 
 	let query: string = '';
 	export let data: PageData;
 	$: inputEmpty = query === '';
+	$: areArticlesPresent = Boolean(data.articles);
 </script>
 
 <main class="pt-10">
@@ -30,22 +32,22 @@
 		</div>
 		<Button id="submit-button" type="submit" disabled={inputEmpty}>検索する</Button>
 	</form>
-	<section class="px-3 pt-5 md:pt-10">
+	<section class="w-full max-w-[60rem] mx-auto px-3 pt-5 md:pt-10">
 		<Tabs>
-			<TabItem open>
+			<TabItem open={!areArticlesPresent}>
 				<div slot="title" class="w-24">
 					<span>タグ一覧</span>
 				</div>
-				<ul id="tag-list" class="flex">
+				<ul id="tag-list" class="flex flex-col md:flex-row gap-5">
 					{#each data.tags as tag}
 						<li>
-							<p>{tag.name}</p>
+							<TagCard {tag} />
 						</li>
 					{/each}
 				</ul>
 			</TabItem>
 			{#if data.articles}
-				<TabItem>
+				<TabItem open>
 					<div slot="title" class="w-24">
 						<span>検索結果</span>
 					</div>

--- a/src/routes/tags/[slug]/+page.svelte
+++ b/src/routes/tags/[slug]/+page.svelte
@@ -16,7 +16,7 @@
 		>
 		<Tooltip triggeredBy="#refresh-tag-button" placement="right">変更する</Tooltip>
 	</h1>
-	<ul class="grid grid-cols-3 gap-5 mt-10">
+	<ul class="grid grid-cols-3 gap-5 mt-10" data-testid="tagged-articles">
 		{#await data.articles}
 			{#each Array(8) as _}
 				<ArticleVerticalCardSkeleton />

--- a/tests/pageObject/searchPage.ts
+++ b/tests/pageObject/searchPage.ts
@@ -25,7 +25,7 @@ export class SearchPage {
 	}
 
 	async clickTag(tagName: string) {
-		const tagLinkItem = this.tagsList.getByText(tagName);
+		const tagLinkItem = this.tagsList.getByRole('link', { name: tagName });
 		await tagLinkItem.click();
 	}
 

--- a/tests/pageObject/taggedArticlesPage.ts
+++ b/tests/pageObject/taggedArticlesPage.ts
@@ -11,7 +11,7 @@ export class TaggedArticlesPage {
 		this.page = page;
 		this.tag = tag;
 		this.tagText = page.getByRole('heading', { name: tag.name });
-		this.articlesList = page.getByRole('listbox');
+		this.articlesList = page.getByTestId('tagged-articles');
 	}
 
 	async goto() {

--- a/tests/search-articles.test.ts
+++ b/tests/search-articles.test.ts
@@ -28,7 +28,6 @@ test.describe('記事検索機能のテスト', () => {
 		await searchPage.goto();
 		await searchPage.clickTag(tag.name);
 
-
 		// /tags/:tagId に遷移している
 		await expect(page).toHaveURL(`/tags/${tag.slug}`);
 
@@ -45,7 +44,6 @@ test.describe('記事検索機能のテスト', () => {
 		await taggedArticlesPage.clickArticle('Test Article 1');
 
 		await expect(page).toHaveURL('/articles/test-article-1');
-
 	});
 
 	test('キーワードが空文字だと検索できない', async ({ page }, testInfo) => {

--- a/tests/search-articles.test.ts
+++ b/tests/search-articles.test.ts
@@ -1,7 +1,7 @@
 import test, { expect } from '@playwright/test';
 import { SearchPage } from './pageObject/searchPage';
 import type { Tag } from '$lib/features/tag/types/type';
-// import { TaggedArticlesPage } from './pageObject/taggedArticlesPage';
+import { TaggedArticlesPage } from './pageObject/taggedArticlesPage';
 
 test.describe('記事検索機能のテスト', () => {
 	test('キーワードで記事の検索ができる', async ({ page }) => {
@@ -28,19 +28,24 @@ test.describe('記事検索機能のテスト', () => {
 		await searchPage.goto();
 		await searchPage.clickTag(tag.name);
 
-		// タグのコンポーネントは未作成
 
 		// /tags/:tagId に遷移している
-		// expect(page).toHaveURL(`/tags/${tag.id}`);
+		await expect(page).toHaveURL(`/tags/${tag.slug}`);
 
 		// 遷移後
-		// const taggedArticlesPage = new TaggedArticlesPage(page, tag);
+		const taggedArticlesPage = new TaggedArticlesPage(page, tag);
 
 		// タグ名が表示されている
-		// expect(taggedArticlesPage.tagText).toHaveText(tag.name);
+		await expect(taggedArticlesPage.tagText).toHaveText(`タグ : ${tag.name}`);
 
 		// タグの付いた記事が表示されている
-		// expect(taggedArticlesPage.articlesList).toBeVisible();
+		await expect(taggedArticlesPage.articlesList).toBeVisible();
+
+		// 記事をクリックすると記事詳細ページに遷移する
+		await taggedArticlesPage.clickArticle('Test Article 1');
+
+		await expect(page).toHaveURL('/articles/test-article-1');
+
 	});
 
 	test('キーワードが空文字だと検索できない', async ({ page }, testInfo) => {


### PR DESCRIPTION
## 変更箇所
- 検索ページに表示されるタグを`p`から`TagCardに変更`
- 検索ページとタグに紐づいた記事一覧のページのPomを修正
- 検索機能のE2Eテストのコードを`TagCard`の変更に合わせて修正