### PR TITLE
記事のカードコンポーネントの画像の表示を修正

### DIFF
--- a/src/lib/features/article/components/ArticleVerticalCard/ArticleVerticalCard.svelte
+++ b/src/lib/features/article/components/ArticleVerticalCard/ArticleVerticalCard.svelte
@@ -56,7 +56,7 @@
 				/>
 			</a>
 		</div>
-		<div class="p-5 h-72">
+		<div class="p-5 h-72 max-w-[365.84px]">
 			<div class="mb-4 w-full flex justify-between items-center">
 				<TagChipList shouldfilter tags={article.tags} />
 				{#if isBookmarked}

--- a/src/lib/features/tag/components/TagCard/TagCard.test.ts
+++ b/src/lib/features/tag/components/TagCard/TagCard.test.ts
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
 import TagCard from './TagCard.svelte';
 import type { Tag } from '../../types/type';


### PR DESCRIPTION
# やったこと
記事のカードコンポーネントで、右の余白ができる問題を修正